### PR TITLE
Adds onClose() call on SimpleTooltip dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.11] - 23/06/20.
+
+* Some fixes on implementation of route aware logic
+
 ## [0.1.10] - 8/06/20.
 
 * Some fixes on implementation of route aware logic

--- a/lib/src/tooltip.dart
+++ b/lib/src/tooltip.dart
@@ -223,6 +223,11 @@ class _SimpleTooltipState extends State<SimpleTooltip> with RouteAware {
     if (!_displaying) {
       return;
     }
+
+    if (widget.onClose != null) {
+      widget.onClose();
+    }
+
     this.overlayEntry.remove();
     _displaying = false;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simple_tooltip
 description: A simple library for creating tooltips
-version: 0.1.10
+version: 0.1.11
 homepage: https://github.com/victorevox/simple_tooltp
 
 environment:


### PR DESCRIPTION
Currently `onClose()` is not being used at all. This PR aims to give it a proper use by calling it on `SimpleTooltip` dispose method.