### PR TITLE
add horizontal / vertical TooltipDirection

### DIFF
--- a/lib/src/tooltip.dart
+++ b/lib/src/tooltip.dart
@@ -270,12 +270,37 @@ class SimpleTooltipState extends State<SimpleTooltip> with RouteAware {
   OverlayEntry _buildOverlay({
     bool buildHidding = false,
   }) {
+    var direction = widget.tooltipDirection;
+
+    if (direction == TooltipDirection.horizontal ||
+        direction == TooltipDirection.vertical) {
+      // compute real direction based on target position
+      final targetRenderBox = context.findRenderObject() as RenderBox;
+      final overlayRenderBox = Overlay.of(context, rootOverlay: false)
+          .context
+          .findRenderObject() as RenderBox;
+
+      final targetGlobalCenter = targetRenderBox.localToGlobal(
+          targetRenderBox.size.center(Offset.zero),
+          ancestor: overlayRenderBox);
+
+      direction = (direction == TooltipDirection.vertical)
+          ? (targetGlobalCenter.dy <
+                  overlayRenderBox.size.center(Offset.zero).dy
+              ? TooltipDirection.down
+              : TooltipDirection.up)
+          : (targetGlobalCenter.dx <
+                  overlayRenderBox.size.center(Offset.zero).dx
+              ? TooltipDirection.right
+              : TooltipDirection.left);
+    }
+
     return OverlayEntry(
       builder: (overlayContext) {
         return _BallonPositioner(
           key: _positionerKey,
           link: layerLink,
-          tooltipDirection: widget.tooltipDirection,
+          tooltipDirection: direction,
           maxHeight: widget.maxHeight,
           minHeight: widget.minHeight,
           maxWidth: widget.maxWidth,
@@ -283,7 +308,7 @@ class SimpleTooltipState extends State<SimpleTooltip> with RouteAware {
           child: _BalloonTransition(
             key: _transitionKey,
             duration: widget.animationDuration,
-            tooltipDirection: widget.tooltipDirection,
+            tooltipDirection: direction,
             hide: buildHidding,
             animationEnd: (status) {
               if (status == AnimationStatus.dismissed) {
@@ -299,7 +324,7 @@ class SimpleTooltipState extends State<SimpleTooltip> with RouteAware {
               ballonPadding: widget.ballonPadding,
               borderColor: widget.borderColor,
               borderWidth: widget.borderWidth,
-              tooltipDirection: widget.tooltipDirection,
+              tooltipDirection: direction,
               backgroundColor: widget.backgroundColor,
               shadows: widget.customShadows,
               onTap: () {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,1 +1,1 @@
-enum TooltipDirection { up, down, right, left }
+enum TooltipDirection { up, down, right, left, horizontal, vertical }


### PR DESCRIPTION
add horizontal / vertical TooltipDirection to select up / down or right / left direction automatically based on most room available

if the target widget is in the bottom half of the screen the direction will be up else it will be down, this avoids larger tooltips from going offscreen if the target widget is near the edge