### PR TITLE
Bump version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simple_tooltip
 description: A simple library for creating tooltips
-version: 0.1.16
+version: 0.1.17
 homepage: https://github.com/victorevox/simple_tooltp
 
 environment:


### PR DESCRIPTION
Pub get does not pick the last version and null-safety upgrade will fail if previous version of the package exists.