### PR TITLE
fix Widgetbinding.instance null check issue

### DIFF
--- a/lib/src/ballon_transition.dart
+++ b/lib/src/ballon_transition.dart
@@ -147,7 +147,7 @@ class __OpacityAnimationWrapperState extends State<_OpacityAnimationWrapper> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
       if (mounted) {
         setState(() {
           _opacity = 1;

--- a/lib/src/balloon.dart
+++ b/lib/src/balloon.dart
@@ -53,7 +53,7 @@ class __BallonState extends State<_Ballon> {
 
   @override
   Widget build(BuildContext context) {
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
       if (!mounted) return;
       final RenderBox? renderBox = _containerKey.currentContext!.findRenderObject() as RenderBox?;
       if (renderBox == null) return null;

--- a/lib/src/balloon_positioner.dart
+++ b/lib/src/balloon_positioner.dart
@@ -131,7 +131,7 @@ class __BallonPositionerState extends State<_BallonPositioner> {
       ),
     );
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
       final ballonContext = _ballonKey.currentContext;
       if (ballonContext != null) {
         // final bRenderO = ballonContext.findRenderObject();

--- a/lib/src/obfuscate_tooltip_item.dart
+++ b/lib/src/obfuscate_tooltip_item.dart
@@ -31,7 +31,7 @@ class ObfuscateTooltipItemState extends State<ObfuscateTooltipItem> with Widgets
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance?.addObserver(this);
     _intervalSubscription = Stream.periodic(Duration(seconds: 1)).listen((event) {
       final currentPositionSize = getPositionAndSize();
       if (_lastPositionSize != currentPositionSize) {
@@ -40,7 +40,7 @@ class ObfuscateTooltipItemState extends State<ObfuscateTooltipItem> with Widgets
       }
       _lastPositionSize = currentPositionSize;
     });
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
       _addToTooltips(widget.tooltipKeys);
     });
   }
@@ -56,7 +56,7 @@ class ObfuscateTooltipItemState extends State<ObfuscateTooltipItem> with Widgets
 
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
+    WidgetsBinding.instance?.removeObserver(this);
     _intervalSubscription.cancel();
     _removeFromTooltips(widget.tooltipKeys);
     super.dispose();

--- a/lib/src/tooltip.dart
+++ b/lib/src/tooltip.dart
@@ -155,7 +155,7 @@ class SimpleTooltipState extends State<SimpleTooltip> with RouteAware {
 
   addObfuscateItem(ObfuscateTooltipItemState item) {
     _obfuscateItems.add(item);
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
       doCheckForObfuscation();
       doShowOrHide();
     });
@@ -163,7 +163,7 @@ class SimpleTooltipState extends State<SimpleTooltip> with RouteAware {
 
   removeObfuscatedItem(ObfuscateTooltipItemState item) {
     _obfuscateItems.remove(item);
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
       doCheckForObfuscation();
       doShowOrHide();
     });
@@ -185,7 +185,7 @@ class SimpleTooltipState extends State<SimpleTooltip> with RouteAware {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
       if (shouldShowTooltip) {
         _showTooltip();
       }
@@ -199,7 +199,7 @@ class SimpleTooltipState extends State<SimpleTooltip> with RouteAware {
       oldWidget.routeObserver?.unsubscribe(this);
       widget.routeObserver?.subscribe(this, ModalRoute.of(context) as PageRoute<dynamic>);
     }
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
       if (oldWidget.tooltipDirection != widget.tooltipDirection || (oldWidget.show != widget.show && widget.show)) {
         _transitionKey = GlobalKey();
       }
@@ -358,7 +358,7 @@ class SimpleTooltipState extends State<SimpleTooltip> with RouteAware {
     // Route was pushed onto navigator and is now topmost route.
     if (shouldShowTooltip) {
       _removeTooltip();
-      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
         if (!mounted) return;
         _showTooltip();
       });


### PR DESCRIPTION
This pull request will resolve the following issue -
[https://github.com/victorevox/simple_tooltp/issues/41](https://github.com/victorevox/simple_tooltp/issues/41)

C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/tooltip.dart:158:29: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
                            ^^^^^^^^^^^^^^^^^^^^

/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/tooltip.dart:166:29: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.

    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
                            ^^^^^^^^^^^^^^^^^^^^
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/tooltip.dart:188:29: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.addPostFrameCallback((_) {
                            ^^^^^^^^^^^^^^^^^^^^

/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/tooltip.dart:202:29: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.addPostFrameCallback((_) {

                            ^^^^^^^^^^^^^^^^^^^^
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/tooltip.dart:361:31: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
                              ^^^^^^^^^^^^^^^^^^^^
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/ballon_transition.dart:150:29: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {

                            ^^^^^^^^^^^^^^^^^^^^
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/balloon.dart:56:29: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.

    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
                            ^^^^^^^^^^^^^^^^^^^^
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/balloon_positioner.dart:134:29: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.

    WidgetsBinding.instance.addPostFrameCallback((_) {
                            ^^^^^^^^^^^^^^^^^^^^
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/obfuscate_tooltip_item.dart:34:29: Error: Method 'addObserver' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.

    WidgetsBinding.instance.addObserver(this);
                            ^^^^^^^^^^^
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/obfuscate_tooltip_item.dart:43:29: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
                            ^^^^^^^^^^^^^^^^^^^^
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/simple_tooltip-1.2.0/lib/src/obfuscate_tooltip_item.dart:59:29: Error: Method 'removeObserver' cannot be called on 'WidgetsBinding?' because it is potentially null.
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.removeObserver(this);
                            ^^^^^^^^^^^^^^
Restarted application in 1,111ms.